### PR TITLE
字符串类型字段支持时间戳函数作为逻辑删除值

### DIFF
--- a/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
+++ b/mybatis-plus-core/src/main/java/com/baomidou/mybatisplus/core/metadata/TableInfo.java
@@ -439,7 +439,8 @@ public class TableInfo implements Constants {
         if (NULL.equalsIgnoreCase(value)) {
             return targetStr + NULL;
         } else {
-            return targetStr + String.format(logicDeleteFieldInfo.isCharSequence() ? "'%s'" : "%s", value);
+            boolean valueIsFunction = "NOW()".equalsIgnoreCase(value) || "UNIX_TIMESTAMP()".equalsIgnoreCase(value);
+            return targetStr + String.format((logicDeleteFieldInfo.isCharSequence() && !valuesIsFunction ?) "'%s'" : "%s", value);
         }
     }
 


### PR DESCRIPTION
目前有一个问题，就是如果我的is_deleted字段是字符串，并且要计算在唯一索引的时候，我想设置内容为now()，但是代码里限制了，只要是字符串，就会把now()作为字符串传进去。所以在这里判断一下，支持字符串类型也适用时间戳函数来作为逻辑删除值

### 该Pull Request关联的Issue



### 修改描述



### 测试用例



### 修复效果的截屏


